### PR TITLE
Convert test_job_Ali to GitHub Actions

### DIFF
--- a/.github/workflows/test_job_ali.yml
+++ b/.github/workflows/test_job_ali.yml
@@ -1,0 +1,20 @@
+name: test_job_Ali
+on:
+  workflow_dispatch:
+env:
+#   # This item has no matching transformer
+#   org.jenkinsci.plugins.builduser.BuildUser:
+#     plugin: build-user-vars-plugin@1.5
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - qdw_secondary
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: run batch command
+      shell: cmd
+      run: |-
+        IF NOT EXIST "E:\Ali_test\testing_permissions\test.ps1" exit -1
+        PowerShell.exe -ExecutionPolicy ByPass -noprofile -file "E:\Ali_test\testing_permissions\test.ps1"


### PR DESCRIPTION
Pipeline migrated from [Jenkins](https://jenkinsmaster.arcadiahosted.local:8443/job/test_job_Ali/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### test_job_Ali
- [ ] Ensure a runner with the following labels exists: qdw_secondary